### PR TITLE
PropTypes from prop-types lib

### DIFF
--- a/Calendar.js
+++ b/Calendar.js
@@ -1,8 +1,7 @@
 'use strict';
 
-import React, {
-	PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
 	ListView,
 	StyleSheet,


### PR DESCRIPTION
Latest versions of the react lib don't export the PropTypes object anymore.